### PR TITLE
feat: added new field to capture failure message in CI failed event 

### DIFF
--- a/specs/api-spec.yaml
+++ b/specs/api-spec.yaml
@@ -82,6 +82,8 @@ components:
           type: string
         material:
           $ref: '#/components/schemas/MaterialTriggerInfo'
+        failedStepName:
+          type: string
     MaterialTriggerInfo:
       type: object
       properties:

--- a/specs/api-spec.yaml
+++ b/specs/api-spec.yaml
@@ -82,7 +82,7 @@ components:
           type: string
         material:
           $ref: '#/components/schemas/MaterialTriggerInfo'
-        failedStepName:
+        failureReason:
           type: string
     MaterialTriggerInfo:
       type: object

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -87,8 +87,8 @@ export class MustacheHelper {
                 pipelineName: event.payload.pipelineName || "NA",
                 ciMaterials: ciMaterials,
                 buildHistoryLink: buildHistoryLink,
-                failedStepName: event.payload.failedStepName || "NA",
-                isStepFailed: event.payload.failedStepName != ""
+                failureReason: event.payload.failureReason || "NA",
+                failureReasonExists: event.payload.failedStepName != ""
             }
         }
         else if (event.pipelineType === "CD") {
@@ -162,8 +162,8 @@ interface ParsedCIEvent {
         webhookData: WebhookData;
     }[];
     buildHistoryLink: string;
-    failedStepName: string;
-    isStepFailed: boolean;
+    failureReason: string;
+    failureReasonExists: boolean;
 }
 
 interface ParsedCDEvent {

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -80,16 +80,18 @@ export class MustacheHelper {
         if (event.pipelineType === "CI") {
             let buildHistoryLink;
             if (baseURL && event.payload.buildHistoryLink) buildHistoryLink = `${baseURL}${event.payload.buildHistoryLink}`;
-            return {
+            var parsedEvent:ParsedCIEvent = {
                 eventTime: timestamp,
                 triggeredBy: event.payload.triggeredBy || "NA",
                 appName: event.payload.appName || "NA",
                 pipelineName: event.payload.pipelineName || "NA",
                 ciMaterials: ciMaterials,
-                buildHistoryLink: buildHistoryLink,
-                failureReason: event.payload.failureReason || "NA",
-                failureReasonExists: event.payload.failedStepName != ""
+                buildHistoryLink: buildHistoryLink
             }
+            if(event.payload.failureReason) {
+                parsedEvent.failureReason = event.payload.failureReason
+            }
+            return parsedEvent
         }
         else if (event.pipelineType === "CD") {
             let appDetailsLink, deploymentHistoryLink;
@@ -162,8 +164,7 @@ interface ParsedCIEvent {
         webhookData: WebhookData;
     }[];
     buildHistoryLink: string;
-    failureReason: string;
-    failureReasonExists: boolean;
+    failureReason?: string;
 }
 
 interface ParsedCDEvent {

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -86,7 +86,9 @@ export class MustacheHelper {
                 appName: event.payload.appName || "NA",
                 pipelineName: event.payload.pipelineName || "NA",
                 ciMaterials: ciMaterials,
-                buildHistoryLink: buildHistoryLink
+                buildHistoryLink: buildHistoryLink,
+                failedStepName: event.payload.failedStepName || "NA",
+                isStepFailed: event.payload.failedStepName != ""
             }
         }
         else if (event.pipelineType === "CD") {
@@ -160,6 +162,8 @@ interface ParsedCIEvent {
         webhookData: WebhookData;
     }[];
     buildHistoryLink: string;
+    failedStepName: string;
+    isStepFailed: boolean;
 }
 
 interface ParsedCDEvent {

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -80,7 +80,7 @@ export class MustacheHelper {
         if (event.pipelineType === "CI") {
             let buildHistoryLink;
             if (baseURL && event.payload.buildHistoryLink) buildHistoryLink = `${baseURL}${event.payload.buildHistoryLink}`;
-            var parsedEvent:ParsedCIEvent = {
+            const parsedEvent:ParsedCIEvent = {
                 eventTime: timestamp,
                 triggeredBy: event.payload.triggeredBy || "NA",
                 appName: event.payload.appName || "NA",


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
_added handling for failure message for CI failed events_
## How Has This Been Tested?
Tested manually for success and failed cases on events to notifier with the new data
 <!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

