### PR TITLE
feat:Ability to notify(via email) specific users for requesting image approval

### DIFF
--- a/src/common/eventLogBuilder.ts
+++ b/src/common/eventLogBuilder.ts
@@ -11,7 +11,7 @@ export class EventLogBuilder {
         let notifierEventLog = {
             destination: destination,
             source_id: setting.pipeline_id,
-            pipeline_type: setting.pipeline_type,
+            pipeline_type: setting.pipeline_type ? setting.pipeline_type : "NA", //This is optional as approval event doesn't have pipeline_type
             event_type_id: setting.event_type_id,
             correlation_id: event.correlationId,
             payload: event.payload,

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -123,7 +123,7 @@ export class MustacheHelper {
             if (event.payload.dockerImageUrl) index = event.payload.dockerImageUrl.lastIndexOf(":");
             if (event.payload.imageTagNames) imageTagNames = event.payload.imageTagNames;
             if (event.payload.imageComment) imageComment = event.payload.imageComment;
-            if (event.payload.imageLink) imageLink = event.payload.imageLink;
+            if (baseURL && event.payload.imageApprovalLink) imageLink =`${baseURL}${event.payload.imageApprovalLink}`;
            
             return {
                 eventTime: timestamp,
@@ -134,7 +134,7 @@ export class MustacheHelper {
                 imageTag: index >= 0 ? event.payload.dockerImageUrl.substring(index + 1) : "NA",
                 comment:imageComment,
                 tags:imageTagNames,
-                imageLink:imageLink,
+                imageApprovalLink:imageLink,
             }
             
 
@@ -255,7 +255,7 @@ interface ParsedCDEvent {
     envName: string;
     imageTagNames?:string[];
     imageComment?:string;
-    imageLink?:string;
+    imageApprovalLink?:string;
     stage: "Pre-deployment" | "Post-deployment" | "Deployment";
     ciMaterials: {
         branch: string;

--- a/src/common/mustacheHelper.ts
+++ b/src/common/mustacheHelper.ts
@@ -34,10 +34,12 @@ export class MustacheHelper {
         return "NA"
     }
 
-    parseEvent(event: Event, isSlackNotification?: boolean): ParsedCIEvent | ParsedCDEvent {
+    parseEvent(event: Event, isSlackNotification?: boolean): ParsedCIEvent | ParsedCDEvent | ParseApprovalEvent{
         let baseURL = event.baseUrl;
         let material = event.payload.material;
-        let ciMaterials = material.ciMaterials ? material.ciMaterials.map((ci) => {
+        let ciMaterials;
+        if (event.eventTypeId!==4){
+        ciMaterials = material.ciMaterials ? material.ciMaterials.map((ci) => {
             if (material && material.gitTriggers && material.gitTriggers[ci.id]) {
                 let trigger = material.gitTriggers[ci.id];
                 let _material;
@@ -70,6 +72,7 @@ export class MustacheHelper {
                 }
             }
         }) : [];
+    }
 
 
         const date = moment(event.eventTime);
@@ -113,6 +116,28 @@ export class MustacheHelper {
                 appDetailsLink: appDetailsLink,
                 deploymentHistoryLink: deploymentHistoryLink,
             }
+        }
+        else if (event.eventTypeId===4){
+            let  imageTagNames,imageComment,imageLink;
+            let index = -1;
+            if (event.payload.dockerImageUrl) index = event.payload.dockerImageUrl.lastIndexOf(":");
+            if (event.payload.imageTagNames) imageTagNames = event.payload.imageTagNames;
+            if (event.payload.imageComment) imageComment = event.payload.imageComment;
+            if (event.payload.imageLink) imageLink = event.payload.imageLink;
+           
+            return {
+                eventTime: timestamp,
+                triggeredBy: event.payload.triggeredBy || "NA",
+                appName: event.payload.appName || "NA",
+                envName: event.payload.envName || "NA",
+                pipelineName: event.payload.pipelineName || "NA",
+                imageTag: index >= 0 ? event.payload.dockerImageUrl.substring(index + 1) : "NA",
+                comment:imageComment,
+                tags:imageTagNames,
+                imageLink:imageLink,
+            }
+            
+
         }
     }
     parseEventForWebhook(event: Event ) :WebhookParsedEvent {
@@ -209,6 +234,18 @@ interface WebhookParsedEvent{
     devtronContainerImageTag?:string;
     devtronContainerImageRepo?:string;
 }
+interface ParseApprovalEvent{
+    eventTime: number | string;
+    triggeredBy: string;
+    appName: string;
+    pipelineName: string;
+    envName: string;
+    tags?:string[];
+    comment?:string;
+    imageLink?:string;
+    imageTag: string;
+
+}
 
 interface ParsedCDEvent {
     eventTime: number | string;
@@ -216,6 +253,9 @@ interface ParsedCDEvent {
     appName: string;
     pipelineName: string;
     envName: string;
+    imageTagNames?:string[];
+    imageComment?:string;
+    imageLink?:string;
     stage: "Pre-deployment" | "Post-deployment" | "Deployment";
     ciMaterials: {
         branch: string;

--- a/src/destination/destinationHandlers/sesHandler.ts
+++ b/src/destination/destinationHandlers/sesHandler.ts
@@ -160,8 +160,16 @@ export class SESService implements Handler {
             let parsedEvent = this.mh.parseEvent(event);
             parsedEvent['fromEmail'] = event.payload['fromEmail'];
             parsedEvent['toEmail'] = event.payload['toEmail'];
-
-            let json = Mustache.render(template, parsedEvent)
+            let json: string
+            if(event.eventTypeId===4){
+                let commentDisplayStyle = (event.payload.imageComment === "") ? 'none' : 'inline';
+                let tagDisplayStyle = (event.payload.imageTagNames === null) ? 'none' : 'inline';
+                json = Mustache.render(template, { ...parsedEvent, commentDisplayStyle ,tagDisplayStyle});
+            }else{
+                json = Mustache.render(template, parsedEvent)
+            }
+           
+            
             const res = await sdk.send(
                 {
                     email: JSON.parse(json)

--- a/src/destination/destinationHandlers/smtpHandler.ts
+++ b/src/destination/destinationHandlers/smtpHandler.ts
@@ -164,8 +164,14 @@ export class SMTPService implements Handler {
             let parsedEvent = this.mh.parseEvent(event);
             parsedEvent['fromEmail'] = event.payload['fromEmail'];
             parsedEvent['toEmail'] = event.payload['toEmail'];
-
-            let json = Mustache.render(template, parsedEvent)
+            let json: string
+            if(event.eventTypeId===4){
+                let commentDisplayStyle = (event.payload.imageComment === "") ? 'none' : 'inline';
+                let tagDisplayStyle = (event.payload.imageTagNames === null) ? 'none' : 'inline';
+                json = Mustache.render(template, { ...parsedEvent, commentDisplayStyle ,tagDisplayStyle});
+            }else{
+                json = Mustache.render(template, parsedEvent)
+            }
             const res = await sdk.send(
                 {
                     email: JSON.parse(json)

--- a/src/notification/service/notificationService.ts
+++ b/src/notification/service/notificationService.ts
@@ -6,6 +6,8 @@ import {NotificationSettings} from "../../entities/notificationSettings";
 import { WebhookConfig } from "../../entities/webhookconfig";
 import { settings } from "cluster";
 import { WebhookService } from "../../destination/destinationHandlers/webhookHandler";
+import { SESService } from "../../destination/destinationHandlers/sesHandler";
+import { SMTPService } from "../../destination/destinationHandlers/smtpHandler";
 
 export interface Handler {
     handle(event: Event, templates: (NotificationTemplates[] | WebhookConfig[]), setting: NotificationSettings, configMap: Map<string, boolean>, destinationMap: Map<string, boolean>): boolean
@@ -56,8 +58,11 @@ class NotificationService {
                         settings.config = event.payload.providers
                         settings.pipeline_id = event.pipelineId
                         settings.event_type_id = event.eventTypeId
+                        
                         for (let h of this.handlers) {
+                            if ((h instanceof SESService) || (h instanceof SMTPService)){
                             h.handle(event, templateResults, settings, configsMap, destinationMap)
+                            }
                         }
                     })
 

--- a/src/notification/service/notificationService.ts
+++ b/src/notification/service/notificationService.ts
@@ -27,9 +27,48 @@ class NotificationService {
         this.templatesRepository = templatesRepository
         this.logger = logger
     }
+    public sendApprovalNotificaton(event:Event){
+        if (!this.isValidEventForApproval(event)) {
+            return
+        }
+        this.logger.info('notificationSettingsRepository.findByEventSource')
+          if (!event.payload.providers || event.payload.providers == 0) {
+                this.logger.info("no notification settings found for event " + event.correlationId);
+                return
+            }
+            let destinationMap = new Map();
+            let configsMap = new Map();
+            this.logger.info("notification settings " );
+            this.logger.info(JSON.stringify(event.payload.providers))
+            event.payload.providers.forEach((setting) => {
+                const providerObjects = setting
+                    let id = providerObjects['dest'] + '-' + providerObjects['configId']
+                    configsMap.set(id, false)
+            });
+            
+
+                    this.templatesRepository.findByEventTypeId(event.eventTypeId).then((templateResults:NotificationTemplates[]) => {
+                        if (!templateResults) {
+                            this.logger.info("no templates found for event ", event);
+                            return
+                        }
+                        let settings = new NotificationSettings()
+                        settings.config = event.payload.providers
+                        settings.pipeline_id = event.pipelineId
+                        settings.event_type_id = event.eventTypeId
+                        for (let h of this.handlers) {
+                            h.handle(event, templateResults, settings, configsMap, destinationMap)
+                        }
+                    })
+
+    }
 
     public sendNotification(event: Event) {
 
+    if (event.payload.providers){
+            this.sendApprovalNotificaton(event)
+            return
+        }
         if (!this.isValidEvent(event)) {
             return
         }
@@ -78,7 +117,7 @@ class NotificationService {
                           });
                     });   
                 }
-                if (configArray.length>webhookConfig.length){
+                if (configArray.length > webhookConfig.length){
                     this.templatesRepository.findByEventTypeIdAndNodeType(event.eventTypeId, event.pipelineType).then((templateResults:NotificationTemplates[]) => {
                         if (!templateResults) {
                             this.logger.info("no templates found for event ", event);
@@ -99,12 +138,17 @@ class NotificationService {
             return true;
         return false;
     }
+    private isValidEventForApproval(event: Event) {
+        if (event.eventTypeId && event.correlationId && event.payload && event.baseUrl)
+            return true;
+        return false;
+    }
 }
 
 class Event {
     eventTypeId: number
     pipelineId: number
-    pipelineType: string
+    pipelineType?: string
     correlationId?: number | string
     payload: any
     eventTime: string

--- a/src/repository/templatesRepository.ts
+++ b/src/repository/templatesRepository.ts
@@ -12,6 +12,14 @@ export class NotificationTemplatesRepository {
             }
         });
     }
+    findByEventTypeId(eventTypeId: number) {
+      return getManager().getRepository(NotificationTemplates).find({
+          where: {
+              event_type_id: eventTypeId,
+             
+          }
+      });
+  }
 }
 export class WebhookConfigRepository {
     async getAllWebhookConfigs() {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description

- While requesting approval for an image, the requester can choose the approvers they want to notify. //All approvers will be able to approve irrespective of if they were notified or not.

- The selected approvers will receive an approval request via email. The email will contain details of the request with a CTA to navigate directly to the image for which approval is requested.


Fixes [#AB4171](https://dev.azure.com/DevtronLabs/Devtron/_boards/board/t/Infra/Stories/?workitem=4171)

## How Has This Been Tested?
All test are performed locally

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

